### PR TITLE
7 swagger api 문서를 설정한다

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/feed/controller/FeedControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/feed/controller/FeedControllerDocs.java
@@ -1,23 +1,16 @@
 package com.example.purithm.domain.feed.controller;
 
 import com.example.purithm.domain.feed.dto.response.FeedDto;
-import com.example.purithm.global.response.ErrorResponse;
 import com.example.purithm.global.response.SuccessResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 public interface FeedControllerDocs {
-  @Operation(summary = "피드를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "피드 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "OK")
   public SuccessResponse<List<FeedDto>> getFeeds(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @RequestParam(value = "sortedBy", required = false) @Parameter(description = "정렬순",

--- a/purithm/src/main/java/com/example/purithm/domain/feed/dto/response/FeedDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/feed/dto/response/FeedDto.java
@@ -3,22 +3,23 @@ package com.example.purithm.domain.feed.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Date;
 import java.util.List;
+import lombok.Getter;
 
-public record FeedDto(
+@Schema(description = "피드 정보 응답 dto")
+@Getter
+public class FeedDto {
     @Schema(description = "필터 id")
-    Long filterId,
+    Long filterId;
     @Schema(description = "작가")
-    String writer,
+    String writer;
     @Schema(description = "작가 프로필")
-    String profile,
+    String profile;
     @Schema(description = "퓨어 지수")
-    int pureDegree,
+    int pureDegree;
     @Schema(description = "피드 생성 날짜")
-    Date createdAt,
+    Date createdAt;
     @Schema(description = "피드 사진들")
-    List<String> pictures,
+    List<String> pictures;
     @Schema(description = "필터 이름")
-    String filterName
-) {
-
+    String filterName;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -26,7 +26,7 @@ public class FilterController implements FilterControllerDocs {
   }
 
   @GetMapping("/{filterId}")
-  public SuccessResponse<FilterDetailDto> getFilterDetail(String authorization, Long filterId) {
+  public SuccessResponse<FilterDetailDto> getFilterDetail(String authorization, String os, Long filterId) {
     return null;
   }
 

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
@@ -34,6 +34,8 @@ public interface FilterControllerDocs {
   @ApiResponse(responseCode = "200", description = "Ok", useReturnTypeSchema = true)
   public SuccessResponse<FilterDetailDto> getFilterDetail(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
+      @RequestParam(value = "os", required = true) @Parameter(description = "휴대폰 os",
+          examples = {@ExampleObject(value = "AOS"), @ExampleObject(value = "iOS")}) String os,
       @PathVariable Long filterId);
 
   @Operation(summary = "작가의 말을 조회합니다.")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
@@ -4,13 +4,10 @@ import com.example.purithm.domain.filter.dto.response.FilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDto;
 import com.example.purithm.domain.filter.dto.response.PhotographerDescriptionDto;
 import com.example.purithm.domain.filter.dto.response.ReviewDto;
-import com.example.purithm.global.response.ErrorResponse;
 import com.example.purithm.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,9 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 public interface FilterControllerDocs {
   @Operation(summary = "메인 홈에서 간략한 필터 정보를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "필터 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "필터 조회 성공")
   public SuccessResponse<List<FilterDto>> getFilters(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @RequestParam(value = "os", required = true) @Parameter(description = "휴대폰 os",
@@ -35,41 +30,32 @@ public interface FilterControllerDocs {
   );
 
   @Operation(summary = "필터 상세 정보를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "필터 상세 정보 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "필터 상세 정보 조회 성공")
+  @ApiResponse(responseCode = "200", description = "Ok", useReturnTypeSchema = true)
   public SuccessResponse<FilterDetailDto> getFilterDetail(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long filterId);
 
   @Operation(summary = "작가의 말을 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "작가의 말 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "작가의 말 조회 성공")
   public SuccessResponse<PhotographerDescriptionDto> getPhotographerDescription(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long filterId);
 
   @Operation(summary = "필터 상세에서 필터 리뷰들을 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "필터 리뷰 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "필터 리뷰 조회 성공")
   public SuccessResponse<List<ReviewDto>> getReviews(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long filterId);
 
   @Operation(summary = "필터 좋아요를 누릅니다.")
-  @ApiResponse(responseCode = "200", description = "필터 좋아요 누르기 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "필터 좋아요 누르기 성공")
   public SuccessResponse<Boolean> likes(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long filterId);
 
   @Operation(summary = "필터 좋아요를 취소합니다.")
-  @ApiResponse(responseCode = "200", description = "필터 좋아요 취소하기 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "필터 좋아요 취소하기 성공")
   public SuccessResponse<Boolean> deleteLikes(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long filterId);

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/AOSFilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/AOSFilterDetailDto.java
@@ -1,7 +1,9 @@
 package com.example.purithm.domain.filter.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
+@Getter
 public class AOSFilterDetailDto extends FilterDetailDto {
   @Schema(description = "라이트 밸런스")
   private int lightBalance;

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDetailDto.java
@@ -2,7 +2,10 @@ package com.example.purithm.domain.filter.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import lombok.Getter;
 
+@Schema(description = "필터 상세 정보")
+@Getter
 public abstract class FilterDetailDto {
     @Schema(description = "필터 이름")
     String name;

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/iOSFilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/iOSFilterDetailDto.java
@@ -1,7 +1,9 @@
 package com.example.purithm.domain.filter.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
+@Getter
 public class iOSFilterDetailDto extends FilterDetailDto {
   @Schema(description = "노출")
   private int exposure;

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/Filter.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/Filter.java
@@ -33,4 +33,6 @@ public class Filter {
   @Convert(converter = StringListConverter.class)
   private List<String> pictures;
   private Membership membership;
+
+  private OS os;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/OS.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/OS.java
@@ -1,0 +1,10 @@
+package com.example.purithm.domain.filter.entity;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum OS {
+  iOS("iOS"),
+  AOS("AOS");
+  private final String os;
+}

--- a/purithm/src/main/java/com/example/purithm/domain/photographer/controller/PhotographerControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/photographer/controller/PhotographerControllerDocs.java
@@ -5,9 +5,7 @@ import com.example.purithm.domain.photographer.dto.response.PhotographerFilterDt
 import com.example.purithm.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,9 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 public interface PhotographerControllerDocs {
   @Operation(summary = "작가 정보를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "작가 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "작가 조회 성공")
   public SuccessResponse<List<PhotographerDto>> getPhotographers(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @RequestParam(value = "sortedBy", required = false) @Parameter(description = "정렬순",
@@ -29,9 +25,7 @@ public interface PhotographerControllerDocs {
   );
 
   @Operation(summary = "특정 작가의 필터를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "작가의 필터 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "작가의 필터 조회 성공")
   public SuccessResponse<List<PhotographerFilterDto>> getFiltersByPhotographer(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long photographerId,

--- a/purithm/src/main/java/com/example/purithm/domain/review/controller/ReviewControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/review/controller/ReviewControllerDocs.java
@@ -1,12 +1,9 @@
 package com.example.purithm.domain.review.controller;
 
 import com.example.purithm.domain.review.dto.response.ReviewResponseDto;
-import com.example.purithm.global.response.ErrorResponse;
 import com.example.purithm.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,17 +11,13 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 public interface ReviewControllerDocs {
   @Operation(summary = "리뷰 상세 정보를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "리뷰 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "리뷰 조회 성공")
   public SuccessResponse<ReviewResponseDto> getReviewDetail(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long reviewId);
 
   @Operation(summary = "리뷰를 작성합니다.")
-  @ApiResponse(responseCode = "200", description = "리뷰 작성 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "리뷰 작성 성공")
   public SuccessResponse<Void> writeReview(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @RequestBody ReviewResponseDto request);

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
@@ -2,17 +2,13 @@ package com.example.purithm.domain.user.controller;
 
 import com.example.purithm.domain.user.dto.request.UserInfoRequestDto;
 import com.example.purithm.domain.user.dto.response.AccountInfoDto;
-import com.example.purithm.domain.user.dto.response.MyFilterDto;
 import com.example.purithm.domain.user.dto.response.MyPickDto;
 import com.example.purithm.domain.user.dto.response.MyReviewDto;
 import com.example.purithm.domain.user.dto.response.StampDto;
 import com.example.purithm.domain.user.dto.response.UserInfoDto;
-import com.example.purithm.global.response.ErrorResponse;
 import com.example.purithm.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,57 +17,43 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 public interface UserControllerDocs {
   @Operation(summary = "내 프로필을 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "내 프로필 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 프로필 조회 성공")
   public SuccessResponse<UserInfoDto> getMyInfo(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization
   );
 
   @Operation(summary = "내 프로필을 수정합니다.")
-  @ApiResponse(responseCode = "200", description = "내 프로필 수정 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 프로필 수정 성공")
   public SuccessResponse<Void> changeProfile(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @RequestBody UserInfoRequestDto userInfoRequestDto);
 
   @Operation(summary = "내 계정 정보를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "내 계정 정보 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 계정 정보 조회 성공")
   public SuccessResponse<AccountInfoDto> getAccountInfo(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization
   );
 
   @Operation(summary = "내 스탬프를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "내 스탬프 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 스탬프 조회 성공")
   public SuccessResponse<List<StampDto>> getStamp(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization
   );
 
   @Operation(summary = "내 리뷰를 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공")
   public SuccessResponse<List<MyReviewDto>> getMyReview(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization
   );
 
   @Operation(summary = "내 리뷰를 삭제합니다.")
-  @ApiResponse(responseCode = "200", description = "내 리뷰 삭제 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 리뷰 삭제 성공")
   public SuccessResponse<Void> deleteReview(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @PathVariable Long reviewId);
 
   @Operation(summary = "내 찜 목록을 조회합니다.")
-  @ApiResponse(responseCode = "200", description = "내 찜 목록 조회 성공",
-      content = @Content(mediaType = "application/json",
-          schema = @Schema(implementation = SuccessResponse.class)))
+  @ApiResponse(responseCode = "200", description = "내 찜 목록 조회 성공")
   public SuccessResponse<List<MyPickDto>> getMyPick(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization
   );

--- a/purithm/src/main/java/com/example/purithm/global/auth/argumentresolver/LoginUserArgumentResolver.java
+++ b/purithm/src/main/java/com/example/purithm/global/auth/argumentresolver/LoginUserArgumentResolver.java
@@ -3,6 +3,7 @@ package com.example.purithm.global.auth.argumentresolver;
 import com.example.purithm.global.auth.annotation.LoginInfo;
 import com.example.purithm.global.auth.entity.CustomOAuth2User;
 import com.example.purithm.global.exception.CustomException;
+import com.example.purithm.global.exception.Error;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
@@ -31,10 +32,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
 
     if (user.getName().equals("anonymousUser")) {
-      throw CustomException.builder()
-          .code(401)
-          .message("로그인 되지 않은 사용자입니다.")
-          .build();
+      throw CustomException.of(Error.INVALID_TOKEN_ERROR);
     }
 
     return user;

--- a/purithm/src/main/java/com/example/purithm/global/auth/controller/AuthControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/global/auth/controller/AuthControllerDocs.java
@@ -1,0 +1,33 @@
+package com.example.purithm.global.auth.controller;
+
+import com.example.purithm.global.response.SuccessResponse;
+import com.nimbusds.jose.JOSEException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.IOException;
+import java.text.ParseException;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import reactor.core.publisher.Mono;
+
+public interface AuthControllerDocs {
+  @Operation(
+      summary = "Kakao Login",
+      parameters = {
+          @Parameter(name = "Authorization", description = "kakao access token을 보냅니다. Bearer token 형식입니다.", required = true, in = ParameterIn.HEADER)
+      }
+  )
+  public Mono<SuccessResponse<String>> kakaoLogin(@RequestHeader("Authorization") String token);
+
+  @Operation(
+      summary = "Apple Login",
+      parameters = {
+          @Parameter(name = "Authorization", description = "Apple access token을 보냅니다. Bearer token 형식입니다.", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "string"))
+      }
+  )
+  public SuccessResponse<String> appleLogin(
+      @RequestHeader("Authorization") String token, @RequestBody String email)
+      throws IOException, ParseException, JOSEException;
+}

--- a/purithm/src/main/java/com/example/purithm/global/auth/dto/request/AppleLoginRequestDto.java
+++ b/purithm/src/main/java/com/example/purithm/global/auth/dto/request/AppleLoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.purithm.global.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AppleLoginRequestDto(
+    @Schema(description = "토큰")
+    String token,
+    @Schema(description = "이메일")
+    String email
+) {
+
+}

--- a/purithm/src/main/java/com/example/purithm/global/config/SwaggerConfig.java
+++ b/purithm/src/main/java/com/example/purithm/global/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.example.purithm.global.config;
 
+import com.example.purithm.global.exception.CustomException;
+import com.example.purithm.global.exception.Error;
 import com.example.purithm.global.response.ErrorResponse;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverters;
@@ -56,11 +58,13 @@ public class SwaggerConfig {
               .content(new Content().addMediaType("application/json",
                   new MediaType()
                       .schema(resolvedSchema.schema)
-                      .example(new ErrorResponse(40100, "토큰 검증에 실패했습니다."))));
+                      .example(ErrorResponse.of(CustomException.of(Error.INVALID_TOKEN_ERROR)))));
           ApiResponse notFoundResponse = new ApiResponse()
               .description("리소스를 찾을 수 없음")
               .content(new Content().addMediaType("application/json",
-                  new MediaType().schema(resolvedSchema.schema)));
+                  new MediaType()
+                      .schema(resolvedSchema.schema)
+                      .example(ErrorResponse.of(CustomException.of(Error.NOT_FOUND_ERROR)))));
 
           operation.getResponses().addApiResponse("401", unauthorizedResponse);
           operation.getResponses().addApiResponse("404", notFoundResponse);

--- a/purithm/src/main/java/com/example/purithm/global/exception/CustomException.java
+++ b/purithm/src/main/java/com/example/purithm/global/exception/CustomException.java
@@ -1,13 +1,17 @@
 package com.example.purithm.global.exception;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
-@Builder
 @AllArgsConstructor
 public class CustomException extends RuntimeException{
-  int code;
-  String message;
+  private final HttpStatus httpStatus;
+  private final int code;
+  private final String message;
+
+  public static CustomException of(Error error) {
+    return new CustomException(error.getHttpStatus(), error.getCode(), error.getMessage());
+  }
 }

--- a/purithm/src/main/java/com/example/purithm/global/exception/Error.java
+++ b/purithm/src/main/java/com/example/purithm/global/exception/Error.java
@@ -1,0 +1,31 @@
+package com.example.purithm.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum Error {
+  /* 400 */
+  BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 40000, "적절하지 않은 요청입니다."),
+
+  /* 401 */
+  INVALID_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, 40100, "유효하지 않은 토큰입니다."),
+  EXPIRED_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, 40101, "만료된 토큰입니다."),
+
+  /* 404 */
+  NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, 40400, "리소스를 찾을 수 없습니다."),
+
+  /* 409 */
+  NICKNAME_ALREADY_USED_ERROR(HttpStatus.CONFLICT, 40900, "이미 사용 중인 닉네임입니다."),
+
+  /* 500 */
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 에러가 발생했습니다."),
+  EXTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "외부 API와 통신에 실패했습니다.");
+
+
+  private final HttpStatus httpStatus;
+  private final int code;
+  private final String message;
+}

--- a/purithm/src/main/java/com/example/purithm/global/exception/GlobalExceptionHandler.java
+++ b/purithm/src/main/java/com/example/purithm/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.example.purithm.global.exception;
 
 import com.example.purithm.global.response.ErrorResponse;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +10,6 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
     ErrorResponse response = ErrorResponse.of(e);
-    return new ResponseEntity<>(response, HttpStatusCode.valueOf(e.getCode()));
+    return new ResponseEntity<>(response, e.getHttpStatus());
   }
 }

--- a/purithm/src/main/java/com/example/purithm/global/response/SuccessResponse.java
+++ b/purithm/src/main/java/com/example/purithm/global/response/SuccessResponse.java
@@ -1,6 +1,8 @@
 package com.example.purithm.global.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -8,12 +10,18 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 @AllArgsConstructor
+@Schema(description = "성공 응답")
+@Builder
 public class SuccessResponse<T> {
+  @Schema(description = "HTTP 상태 코드")
   private final int code;
+  @Schema(description = "응답 메시지")
   private final String message;
+  @Schema(description = "응답 데이터")
   private T data;
 
   public static SuccessResponse of() {
+
     return new SuccessResponse<>(HttpStatus.OK.value(), "ok");
   }
 


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- swagger에 응답 잘 표현 안 되는 거 수정
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ef54e952-a598-4132-b5c3-77218ba758ff">

- swagger 조금 더 자세하게 description 추가
- custom error enum으로 정의
    - custom error throw 하고 GlobalExceptionHandler에서 error 받아서 ErrorResponse 형식으로 전역 Exception 처리
    ```java
        ...

        .onErrorResume(err -> {
              throw CustomException.of(Error.INVALID_TOKEN_ERROR);
        });

        ...
    ```

    이런 식으로 에러 발생했을 때 CustomException throw 한다. 에러 내용은 `/global/exception/Error.java`에 enum으로 정의

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

- enum DB에 어떻게 저장할까
    - [JPA - Enum을 이용해 Column 저장하기](https://galid1.tistory.com/572)
    - [Attribute Converter](https://lng1982.tistory.com/279)

- spring 에러처리 어디서? 어떻게?
    - [스프링 에러 처리](https://velog.io/@6v6/Spring-%EC%8A%A4%ED%94%84%EB%A7%81-%EC%97%90%EB%9F%AC-%EC%B2%98%EB%A6%AC-Error-Handling-for-REST-with-Spring)