### PR TITLE
📝 fix: swagger에 login annotation 제외

### DIFF
--- a/purithm/src/main/java/com/example/purithm/global/auth/annotation/LoginInfo.java
+++ b/purithm/src/main/java/com/example/purithm/global/auth/annotation/LoginInfo.java
@@ -1,5 +1,8 @@
 package com.example.purithm.global.auth.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +10,12 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+    name = "Authorization",
+    description = "JWT 인증 토큰",
+    in = ParameterIn.HEADER,
+    schema = @Schema(type = "string", example = "Bearer YOUR_JWT_TOKEN")
+)
 public @interface LoginInfo {
 
 }

--- a/purithm/src/main/java/com/example/purithm/global/check/CheckController.java
+++ b/purithm/src/main/java/com/example/purithm/global/check/CheckController.java
@@ -2,9 +2,10 @@ package com.example.purithm.global.check;
 
 import com.example.purithm.global.auth.annotation.LoginInfo;
 import com.example.purithm.global.auth.entity.CustomOAuth2User;
+import com.example.purithm.global.exception.CustomException;
+import com.example.purithm.global.exception.Error;
 import com.example.purithm.global.response.SuccessResponse;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,9 +17,10 @@ public class CheckController {
   }
 
   @GetMapping("/api")
-  @ResponseBody
-  public String checkToken(@LoginInfo CustomOAuth2User user) {
-    return user.getName();
+  public SuccessResponse checkLoginUser(@LoginInfo CustomOAuth2User user) {
+    if (user == null) {
+      throw CustomException.of(Error.INVALID_TOKEN_ERROR);
+    }
+    return SuccessResponse.of();
   }
-
 }

--- a/purithm/src/main/java/com/example/purithm/global/config/SwaggerConfig.java
+++ b/purithm/src/main/java/com/example/purithm/global/config/SwaggerConfig.java
@@ -11,13 +11,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
-import java.util.List;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -68,11 +66,6 @@ public class SwaggerConfig {
 
           operation.getResponses().addApiResponse("401", unauthorizedResponse);
           operation.getResponses().addApiResponse("404", notFoundResponse);
-
-          List<Parameter> parameters = operation.getParameters();
-          if (parameters != null) {
-            operation.getParameters().removeIf(param -> param.getName().equals("LoginInfo"));
-          }
         }));
     };
 }

--- a/purithm/src/main/java/com/example/purithm/global/response/SuccessResponse.java
+++ b/purithm/src/main/java/com/example/purithm/global/response/SuccessResponse.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -22,10 +21,10 @@ public class SuccessResponse<T> {
 
   public static SuccessResponse of() {
 
-    return new SuccessResponse<>(HttpStatus.OK.value(), "ok");
+    return new SuccessResponse<>(20000, "정상 처리 되었습니다.");
   }
 
   public static <T> SuccessResponse<T> of(T data) {
-    return new SuccessResponse<>(HttpStatus.OK.value(), "ok", data);
+    return new SuccessResponse<>(20000, "정상 처리 되었습니다.", data);
   }
 }


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- login annotation 만들었더니 관련 내용이 swagger 문서에 추가되어서 제외
query parameter에 아래 내용이 들어가는 문제
```json
{
  "name": "string",
  "attributes": {
    "additionalProp1": {},
    "additionalProp2": {},
    "additionalProp3": {}
  },
  "authorities": [
    {
      "authority": "string"
    }
  ]
}
```

<br>

LoginInfo 어노테이션 수정. `Parameter` 어노테이션 추가

```java
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
@Parameter(
    name = "Authorization",
    description = "JWT 인증 토큰",
    in = ParameterIn.HEADER,
    schema = @Schema(type = "string", example = "Bearer YOUR_JWT_TOKEN")
)
public @interface LoginInfo {

}
```

