### PR TITLE
Feat(#14): 필터 조회 API 추가

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -4,8 +4,12 @@ import com.example.purithm.domain.filter.dto.response.FilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDto;
 import com.example.purithm.domain.filter.dto.response.PhotographerDescriptionDto;
 import com.example.purithm.domain.filter.dto.response.ReviewDto;
+import com.example.purithm.domain.filter.entity.OS;
+import com.example.purithm.domain.filter.service.FilterService;
 import com.example.purithm.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,16 +21,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/filters")
+@RequiredArgsConstructor
 public class FilterController implements FilterControllerDocs {
 
+  private final FilterService filterService;
+
   @GetMapping
-  public SuccessResponse<List<FilterDto>> getFilters(String authorization, String os, String tag, String sortedBy
+  public SuccessResponse<List<FilterDto>> getFilters(Long id, OS os, String tag, String sortedBy
   ) {
-    return null;
+    return SuccessResponse.of(filterService.getFilters(os, tag, sortedBy));
   }
 
   @GetMapping("/{filterId}")
-  public SuccessResponse<FilterDetailDto> getFilterDetail(String authorization, String os, Long filterId) {
+  public SuccessResponse<FilterDetailDto> getFilterDetail(String authorization, OS os, Long filterId) {
     return null;
   }
 

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -32,7 +32,7 @@ public class FilterController implements FilterControllerDocs {
   @GetMapping
   public SuccessResponse<List<FilterDto>> getFilters(Long id, OS os, String tag, String sortedBy, int page, int size
   ) {
-    return SuccessResponse.of(filterService.getFilters(page, size, os, tag, sortedBy));
+    return SuccessResponse.of(filterService.getFilters(id, page, size, os, tag, sortedBy));
   }
 
   @GetMapping("/{filterId}")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -27,9 +27,9 @@ public class FilterController implements FilterControllerDocs {
   private final FilterService filterService;
 
   @GetMapping
-  public SuccessResponse<List<FilterDto>> getFilters(Long id, OS os, String tag, String sortedBy
+  public SuccessResponse<List<FilterDto>> getFilters(Long id, OS os, String tag, String sortedBy, int page, int size
   ) {
-    return SuccessResponse.of(filterService.getFilters(os, tag, sortedBy));
+    return SuccessResponse.of(filterService.getFilters(page, size, os, tag, sortedBy));
   }
 
   @GetMapping("/{filterId}")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -1,12 +1,15 @@
 package com.example.purithm.domain.filter.controller;
 
+import com.example.purithm.domain.filter.dto.response.AOSFilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDto;
+import com.example.purithm.domain.filter.dto.response.IOSFilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.PhotographerDescriptionDto;
 import com.example.purithm.domain.filter.dto.response.ReviewDto;
 import com.example.purithm.domain.filter.entity.OS;
 import com.example.purithm.domain.filter.service.FilterService;
 import com.example.purithm.global.response.SuccessResponse;
+
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
@@ -33,8 +36,18 @@ public class FilterController implements FilterControllerDocs {
   }
 
   @GetMapping("/{filterId}")
-  public SuccessResponse<FilterDetailDto> getFilterDetail(String authorization, OS os, Long filterId) {
-    return null;
+  public SuccessResponse<FilterDetailDto> getFilterDetail(Long id, Long filterId) {
+    return SuccessResponse.of(filterService.getFilterDetail(filterId));
+  }
+
+  @GetMapping("/{filterId}/AOS")
+  public SuccessResponse<AOSFilterDetailDto> getAOSFilter(Long id, Long filterId) {
+    return SuccessResponse.of(filterService.getFilterAOSDetail(filterId));
+  }
+
+  @GetMapping("/{filterId}/iOS")
+  public SuccessResponse<IOSFilterDetailDto> getIOSFilter(Long id, Long filterId) {
+    return SuccessResponse.of(filterService.getFilterIOSDetail(filterId));
   }
 
   @GetMapping("/{filterId}/photographer")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
@@ -4,6 +4,8 @@ import com.example.purithm.domain.filter.dto.response.FilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDto;
 import com.example.purithm.domain.filter.dto.response.PhotographerDescriptionDto;
 import com.example.purithm.domain.filter.dto.response.ReviewDto;
+import com.example.purithm.domain.filter.entity.OS;
+import com.example.purithm.global.auth.annotation.LoginInfo;
 import com.example.purithm.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,9 +20,9 @@ public interface FilterControllerDocs {
   @Operation(summary = "메인 홈에서 간략한 필터 정보를 조회합니다.")
   @ApiResponse(responseCode = "200", description = "필터 조회 성공")
   public SuccessResponse<List<FilterDto>> getFilters(
-      @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
+      @LoginInfo Long id,
       @RequestParam(value = "os", required = true) @Parameter(description = "휴대폰 os",
-        examples = {@ExampleObject(value = "AOS"), @ExampleObject(value = "iOS")}) String os,
+        examples = {@ExampleObject(value = "AOS"), @ExampleObject(value = "iOS")}) OS os,
       @RequestParam(value = "tag", required = false) String tag,
       @RequestParam(value = "sortedBy", required = false) @Parameter(description = "정렬순",
           examples =
@@ -35,7 +37,7 @@ public interface FilterControllerDocs {
   public SuccessResponse<FilterDetailDto> getFilterDetail(
       @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
       @RequestParam(value = "os", required = true) @Parameter(description = "휴대폰 os",
-          examples = {@ExampleObject(value = "AOS"), @ExampleObject(value = "iOS")}) String os,
+          examples = {@ExampleObject(value = "AOS"), @ExampleObject(value = "iOS")}) OS os,
       @PathVariable Long filterId);
 
   @Operation(summary = "작가의 말을 조회합니다.")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
@@ -28,7 +28,9 @@ public interface FilterControllerDocs {
           examples =
               {@ExampleObject(name = "최신순", summary = "최신순 정렬", value = "latest"),
                   @ExampleObject(name = "오래된순", summary = "오래된순 정렬", value = "earliest"),
-                  @ExampleObject(name = "퓨어지수 높은순", summary = "퓨어지수 높은순 정렬", value = "popular")}) String sortedBy
+                  @ExampleObject(name = "퓨어지수 높은순", summary = "퓨어지수 높은순 정렬", value = "popular")}) String sortedBy,
+      @RequestParam(value = "page") int page,
+      @RequestParam(value = "size") int size
   );
 
   @Operation(summary = "필터 상세 정보를 조회합니다.")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
@@ -1,7 +1,9 @@
 package com.example.purithm.domain.filter.controller;
 
+import com.example.purithm.domain.filter.dto.response.AOSFilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDto;
+import com.example.purithm.domain.filter.dto.response.IOSFilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.PhotographerDescriptionDto;
 import com.example.purithm.domain.filter.dto.response.ReviewDto;
 import com.example.purithm.domain.filter.entity.OS;
@@ -35,11 +37,20 @@ public interface FilterControllerDocs {
 
   @Operation(summary = "필터 상세 정보를 조회합니다.")
   @ApiResponse(responseCode = "200", description = "필터 상세 정보 조회 성공")
-  @ApiResponse(responseCode = "200", description = "Ok", useReturnTypeSchema = true)
   public SuccessResponse<FilterDetailDto> getFilterDetail(
-      @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
-      @RequestParam(value = "os", required = true) @Parameter(description = "휴대폰 os",
-          examples = {@ExampleObject(value = "AOS"), @ExampleObject(value = "iOS")}) OS os,
+      @LoginInfo Long id,
+      @PathVariable Long filterId);
+
+  @Operation(summary = "AOS 필터값를 조회합니다.")
+  @ApiResponse(responseCode = "200", description = "필터값 조회 성공")
+  public SuccessResponse<AOSFilterDetailDto> getAOSFilter(
+      @LoginInfo Long id,
+      @PathVariable Long filterId);
+
+  @Operation(summary = "iOS 필터값를 조회합니다.")
+  @ApiResponse(responseCode = "200", description = "필터값 조회 성공")
+  public SuccessResponse<IOSFilterDetailDto> getIOSFilter(
+      @LoginInfo Long id,
       @PathVariable Long filterId);
 
   @Operation(summary = "작가의 말을 조회합니다.")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/AOSFilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/AOSFilterDetailDto.java
@@ -1,10 +1,14 @@
 package com.example.purithm.domain.filter.dto.response;
 
+import com.example.purithm.domain.filter.entity.AOSFilterDetail;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class AOSFilterDetailDto extends FilterDetailDto {
+@Builder
+public class AOSFilterDetailDto {
   @Schema(description = "라이트 밸런스")
   private int lightBalance;
   @Schema(description = "밝기")
@@ -27,4 +31,20 @@ public class AOSFilterDetailDto extends FilterDetailDto {
   private int clear;
   @Schema(description = "명료도")
   private int clarity;
+
+  public static AOSFilterDetailDto of(AOSFilterDetail filterDetail) {
+    return AOSFilterDetailDto.builder()
+        .lightBalance(filterDetail.getLightBalance())
+        .brightness(filterDetail.getBrightness())
+        .exposure(filterDetail.getExposure())
+        .contrast(filterDetail.getContrast())
+        .highlight(filterDetail.getHighlight())
+        .shadow(filterDetail.getShadow())
+        .saturation(filterDetail.getSaturation())
+        .tint(filterDetail.getTint())
+        .temperature(filterDetail.getTemperature())
+        .clear(filterDetail.getClear())
+        .clarity(filterDetail.getClarity())
+        .build();
+  }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDetailDto.java
@@ -2,19 +2,18 @@ package com.example.purithm.domain.filter.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+
+import lombok.Builder;
 import lombok.Getter;
 
 @Schema(description = "필터 상세 정보")
 @Getter
-public abstract class FilterDetailDto {
+@Builder
+public class FilterDetailDto {
     @Schema(description = "필터 이름")
     String name;
-    @Schema(description = "작가 id")
-    Long photographerId;
-    @Schema(description = "작가 이름")
-    String photographerName;
-    @Schema(description = "리뷰 수")
-    int reviews;
+    @Schema(description = "좋아요 수")
+    int likes;
     @Schema(description = "퓨어 지수")
     int pureDegree;
     @Schema(description = "필터 사진")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
@@ -21,10 +21,12 @@ public record FilterDto(
     @Schema(description = "작가 이름")
     String photographerName,
     @Schema(description = "좋아요 수")
-    int likes
+    int likes,
+    @Schema(description = "필터 접근 가능 여부")
+    boolean canAccess
 
 ) {
-    public static FilterDto of(Filter filter) {
+    public static FilterDto of(Filter filter, Membership membership) {
         return FilterDto.builder()
             .id(filter.getId())
             .membership(filter.getMembership())
@@ -33,6 +35,11 @@ public record FilterDto(
             .photographerId(filter.getPhotographer().getId())
             .photographerName(filter.getPhotographer().getUsername())
             .likes(filter.getLikes())
+            .canAccess(checkAccess(membership, filter.getMembership()))
             .build();
+    }
+
+    private static boolean checkAccess(Membership membership, Membership filter) {
+        return filter.compareTo(membership) > 0 ? false : true;
     }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 public record FilterDto(
     @Schema(description = "필터 id")
     Long id,
-    @Schema(description = "필터 타입", example = "basic")
+    @Schema(description = "필터 멤버십 타입", example = "basic")
     Membership membership,
     @Schema(description = "필터 이름")
     String name,

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
@@ -1,14 +1,17 @@
 package com.example.purithm.domain.filter.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import com.example.purithm.domain.filter.entity.Filter;
+import com.example.purithm.domain.filter.entity.Membership;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
 public record FilterDto(
     @Schema(description = "필터 id")
     Long id,
     @Schema(description = "필터 타입", example = "basic")
-    String type,
-    @Schema(description = "필터 태그", example = "뉴진스")
-    String tag,
+    Membership membership,
     @Schema(description = "필터 이름")
     String name,
     @Schema(description = "필터 썸네일")
@@ -21,5 +24,15 @@ public record FilterDto(
     int likes
 
 ) {
-
+    public static FilterDto of(Filter filter) {
+        return FilterDto.builder()
+            .id(filter.getId())
+            .membership(filter.getMembership())
+            .name(filter.getName())
+            .thumbnail(filter.getThumbnail())
+            .photographerId(filter.getPhotographer().getId())
+            .photographerName(filter.getPhotographer().getUsername())
+            .likes(filter.getLikes())
+            .build();
+    }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/IOSFilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/IOSFilterDetailDto.java
@@ -1,10 +1,14 @@
 package com.example.purithm.domain.filter.dto.response;
 
+import com.example.purithm.domain.filter.entity.IOSFilterDetail;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class iOSFilterDetailDto extends FilterDetailDto {
+@Builder
+public class IOSFilterDetailDto {
   @Schema(description = "노출")
   private int exposure;
   @Schema(description = "휘도")
@@ -35,4 +39,24 @@ public class iOSFilterDetailDto extends FilterDetailDto {
   private int noise;
   @Schema(description = "비네트")
   private int vignette;
+
+  public static IOSFilterDetailDto of(IOSFilterDetail filterDetail) {
+    return IOSFilterDetailDto.builder()
+        .exposure(filterDetail.getExposure())
+        .luminance(filterDetail.getLuminance())
+        .highlight(filterDetail.getHighlight())
+        .shadow(filterDetail.getShadow())
+        .contrast(filterDetail.getContrast())
+        .brightness(filterDetail.getBrightness())
+        .blackPoint(filterDetail.getBlackPoint())
+        .saturation(filterDetail.getSaturation())
+        .colorfulness(filterDetail.getColorfulness())
+        .warmth(filterDetail.getWarmth())
+        .hue(filterDetail.getHue())
+        .clear(filterDetail.getClear())
+        .clarity(filterDetail.getClarity())
+        .noise(filterDetail.getNoise())
+        .vignette(filterDetail.getVignette())
+        .build();
+  }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/AOSFilterDetail.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/AOSFilterDetail.java
@@ -1,15 +1,22 @@
 package com.example.purithm.domain.filter.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
+import lombok.Getter;
 
+@Getter
 @Entity
 public class AOSFilterDetail {
   @Id
+  @Column(name = "filter_id", nullable = false)
+  private Long id;
   @OneToOne
   @JoinColumn(name = "filter_id")
+  @MapsId
   private Filter filter;
   private int lightBalance; // 라이트 밸런스
   private int brightness; // 밝기

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/Filter.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/Filter.java
@@ -2,6 +2,8 @@ package com.example.purithm.domain.filter.entity;
 
 import com.example.purithm.domain.photographer.entity.Photographer;
 import com.example.purithm.global.converter.StringListConverter;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,9 +14,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Getter;
+
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.annotation.CreatedDate;
+
+@Getter
 @Entity
 public class Filter {
   @Id
@@ -27,12 +34,13 @@ public class Filter {
   private Photographer photographer;
   private int likes;
   private int price;
-  @Temporal(TemporalType.DATE)
+  @Temporal(TemporalType.TIMESTAMP)
+  @CreatedDate
+  @Column(updatable = false)
   private Date createdAt;
   int pureDegree;
   @Convert(converter = StringListConverter.class)
   private List<String> pictures;
   private Membership membership;
-
   private OS os;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/IOSFilterDetail.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/IOSFilterDetail.java
@@ -1,15 +1,22 @@
 package com.example.purithm.domain.filter.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
+import lombok.Getter;
 
+@Getter
 @Entity
-public class iOSFilterDetail {
+public class IOSFilterDetail {
   @Id
+  @Column(name = "filter_id", nullable = false)
+  private Long id;
   @OneToOne
   @JoinColumn(name = "filter_id")
+  @MapsId
   private Filter filter;
   private int exposure; // 노출
   private int luminance; //휘도

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/Tag.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/Tag.java
@@ -1,0 +1,21 @@
+package com.example.purithm.domain.filter.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Tag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "filter_id")
+	private Filter filter;
+
+	private String tag;
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/AOSFilterDetailRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/AOSFilterDetailRepository.java
@@ -1,0 +1,10 @@
+package com.example.purithm.domain.filter.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.purithm.domain.filter.entity.AOSFilterDetail;
+
+@Repository
+public interface AOSFilterDetailRepository extends JpaRepository<AOSFilterDetail, Long> {
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterRepository.java
@@ -2,6 +2,7 @@ package com.example.purithm.domain.filter.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +11,5 @@ import com.example.purithm.domain.filter.entity.OS;
 
 @Repository
 public interface FilterRepository extends JpaRepository<Filter, Long> {
-	List<Filter> findAllByOsOrderByCreatedAtAsc(OS os);
-	List<Filter> findAllByOsOrderByCreatedAtDesc(OS os);
-	List<Filter> findAllByOsOrderByLikesDesc(OS os);
+	List<Filter> findAllByOs(OS os, Pageable pageable);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterRepository.java
@@ -1,0 +1,16 @@
+package com.example.purithm.domain.filter.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.purithm.domain.filter.entity.Filter;
+import com.example.purithm.domain.filter.entity.OS;
+
+@Repository
+public interface FilterRepository extends JpaRepository<Filter, Long> {
+	List<Filter> findAllByOsOrderByCreatedAtAsc(OS os);
+	List<Filter> findAllByOsOrderByCreatedAtDesc(OS os);
+	List<Filter> findAllByOsOrderByLikesDesc(OS os);
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/IOSFilterDetailRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/IOSFilterDetailRepository.java
@@ -1,0 +1,10 @@
+package com.example.purithm.domain.filter.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.purithm.domain.filter.entity.IOSFilterDetail;
+
+@Repository
+public interface IOSFilterDetailRepository extends JpaRepository<IOSFilterDetail, Long> {
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/TagRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/TagRepository.java
@@ -1,0 +1,24 @@
+package com.example.purithm.domain.filter.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.purithm.domain.filter.entity.Filter;
+import com.example.purithm.domain.filter.entity.OS;
+import com.example.purithm.domain.filter.entity.Tag;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os ORDER BY t.filter.createdAt ASC")
+	List<Filter> findFilterByTagAndOsOrderByCreatedAtAsc(@Param("tag") String tag, @Param("os") OS os);
+
+	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os ORDER BY t.filter.createdAt DESC")
+	List<Filter> findFilterByTagAndOsOrderByCreatedAtDesc(@Param("tag") String tag, @Param("os") OS os);
+
+	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os ORDER BY t.filter.likes DESC")
+	List<Filter> findFilterByTagAndOsOrderByLikesDesc(@Param("tag") String tag, @Param("os") OS os);
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/TagRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/TagRepository.java
@@ -2,6 +2,7 @@ package com.example.purithm.domain.filter.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,12 +14,6 @@ import com.example.purithm.domain.filter.entity.Tag;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
-	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os ORDER BY t.filter.createdAt ASC")
-	List<Filter> findFilterByTagAndOsOrderByCreatedAtAsc(@Param("tag") String tag, @Param("os") OS os);
-
-	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os ORDER BY t.filter.createdAt DESC")
-	List<Filter> findFilterByTagAndOsOrderByCreatedAtDesc(@Param("tag") String tag, @Param("os") OS os);
-
-	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os ORDER BY t.filter.likes DESC")
-	List<Filter> findFilterByTagAndOsOrderByLikesDesc(@Param("tag") String tag, @Param("os") OS os);
+	@Query("SELECT t.filter FROM Tag t WHERE t.tag = :tag AND t.filter.os = :os")
+	List<Filter> findFilterByTagAndOs(@Param("tag") String tag, @Param("os") OS os, Pageable pageable);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
@@ -1,0 +1,35 @@
+package com.example.purithm.domain.filter.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.purithm.domain.filter.dto.response.FilterDto;
+import com.example.purithm.domain.filter.entity.OS;
+import com.example.purithm.domain.filter.repository.FilterRepository;
+import com.example.purithm.domain.filter.repository.TagRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FilterService {
+
+	private final FilterRepository filterRepository;
+	private final TagRepository tagRepository;
+
+	public List<FilterDto> getFilters(OS os, String tag, String sortedBy) {
+		switch (sortedBy) {
+			case "earliest" -> { // 오래된 순 정렬
+				if (tag == null) return filterRepository.findAllByOsOrderByCreatedAtAsc(os).stream().map(FilterDto::of).toList();
+				return tagRepository.findFilterByTagAndOsOrderByCreatedAtAsc(tag, os).stream().map(FilterDto::of).toList();
+			} case "popular" -> { // 퓨어지수 높은 순
+				if (tag == null) return filterRepository.findAllByOsOrderByLikesDesc(os).stream().map(FilterDto::of).toList();
+				return tagRepository.findFilterByTagAndOsOrderByLikesDesc(tag, os).stream().map(FilterDto::of).toList();
+			} default -> { // 정렬 없을 때는 최신 순
+				if (tag == null) return filterRepository.findAllByOsOrderByCreatedAtDesc(os).stream().map(FilterDto::of).toList();
+				return tagRepository.findFilterByTagAndOsOrderByCreatedAtDesc(tag, os).stream().map(FilterDto::of).toList();
+			}
+		}
+	}
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
@@ -2,6 +2,8 @@ package com.example.purithm.domain.filter.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.example.purithm.domain.filter.dto.response.FilterDto;
@@ -18,18 +20,20 @@ public class FilterService {
 	private final FilterRepository filterRepository;
 	private final TagRepository tagRepository;
 
-	public List<FilterDto> getFilters(OS os, String tag, String sortedBy) {
+	public List<FilterDto> getFilters(int page, int size, OS os, String tag, String sortedBy) {
+		PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending()); // 정렬 없을 때는 최신 순
 		switch (sortedBy) {
 			case "earliest" -> { // 오래된 순 정렬
-				if (tag == null) return filterRepository.findAllByOsOrderByCreatedAtAsc(os).stream().map(FilterDto::of).toList();
-				return tagRepository.findFilterByTagAndOsOrderByCreatedAtAsc(tag, os).stream().map(FilterDto::of).toList();
+				pageRequest = PageRequest.of(page, size, Sort.by("createdAt").ascending());
 			} case "popular" -> { // 퓨어지수 높은 순
-				if (tag == null) return filterRepository.findAllByOsOrderByLikesDesc(os).stream().map(FilterDto::of).toList();
-				return tagRepository.findFilterByTagAndOsOrderByLikesDesc(tag, os).stream().map(FilterDto::of).toList();
-			} default -> { // 정렬 없을 때는 최신 순
-				if (tag == null) return filterRepository.findAllByOsOrderByCreatedAtDesc(os).stream().map(FilterDto::of).toList();
-				return tagRepository.findFilterByTagAndOsOrderByCreatedAtDesc(tag, os).stream().map(FilterDto::of).toList();
+				pageRequest = PageRequest.of(page, size, Sort.by("likes").descending());
 			}
 		}
+
+		if (tag == null) {
+			return filterRepository.findAllByOs(os, pageRequest)
+				.stream().map(FilterDto::of).toList();
+		}
+		return tagRepository.findFilterByTagAndOs(tag, os, pageRequest).stream().map(FilterDto::of).toList();
 	}
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
@@ -6,10 +6,20 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import com.example.purithm.domain.filter.dto.response.AOSFilterDetailDto;
+import com.example.purithm.domain.filter.dto.response.FilterDetailDto;
 import com.example.purithm.domain.filter.dto.response.FilterDto;
+import com.example.purithm.domain.filter.dto.response.IOSFilterDetailDto;
+import com.example.purithm.domain.filter.entity.AOSFilterDetail;
+import com.example.purithm.domain.filter.entity.Filter;
+import com.example.purithm.domain.filter.entity.IOSFilterDetail;
 import com.example.purithm.domain.filter.entity.OS;
+import com.example.purithm.domain.filter.repository.AOSFilterDetailRepository;
+import com.example.purithm.domain.filter.repository.IOSFilterDetailRepository;
 import com.example.purithm.domain.filter.repository.FilterRepository;
 import com.example.purithm.domain.filter.repository.TagRepository;
+import com.example.purithm.global.exception.CustomException;
+import com.example.purithm.global.exception.Error;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +29,9 @@ public class FilterService {
 
 	private final FilterRepository filterRepository;
 	private final TagRepository tagRepository;
+	private final IOSFilterDetailRepository iOSFilterDetailRepository;
+	private final AOSFilterDetailRepository aOSFilterDetailRepository;
+
 
 	public List<FilterDto> getFilters(int page, int size, OS os, String tag, String sortedBy) {
 		PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending()); // 정렬 없을 때는 최신 순
@@ -35,5 +48,29 @@ public class FilterService {
 				.stream().map(FilterDto::of).toList();
 		}
 		return tagRepository.findFilterByTagAndOs(tag, os, pageRequest).stream().map(FilterDto::of).toList();
+	}
+
+	public FilterDetailDto getFilterDetail(Long filterId) {
+		Filter filter = filterRepository.findById(filterId)
+			.orElseThrow(() -> CustomException.of(Error.NOT_FOUND_ERROR));
+
+		return FilterDetailDto.builder()
+			.name(filter.getName())
+			.likes(filter.getLikes())
+			.pictures(filter.getPictures())
+			.pictures(filter.getPictures())
+			.build();
+	}
+
+	public AOSFilterDetailDto getFilterAOSDetail(Long filterId) {
+		AOSFilterDetail aosFilterDetail = aOSFilterDetailRepository.findById(filterId)
+			.orElseThrow(() -> CustomException.of(Error.NOT_FOUND_ERROR));
+		return AOSFilterDetailDto.of(aosFilterDetail);
+	}
+
+	public IOSFilterDetailDto getFilterIOSDetail(Long filterId) {
+		IOSFilterDetail iosFilterDetail = iOSFilterDetailRepository.findById(filterId)
+			.orElseThrow(() -> CustomException.of(Error.NOT_FOUND_ERROR));
+		return IOSFilterDetailDto.of(iosFilterDetail);
 	}
 }

--- a/purithm/src/main/java/com/example/purithm/domain/photographer/entity/Photographer.java
+++ b/purithm/src/main/java/com/example/purithm/domain/photographer/entity/Photographer.java
@@ -1,20 +1,35 @@
 package com.example.purithm.domain.photographer.entity;
 
 import com.example.purithm.global.converter.StringListConverter;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+
+import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.annotation.CreatedDate;
+
+@Getter
 @Entity
 public class Photographer {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+  private String username;
   private String profile;
   private String description;
   @Convert(converter = StringListConverter.class)
   private List<String> thumbnails;
+  @Temporal(TemporalType.TIMESTAMP)
+  @CreatedDate
+  @Column(updatable = false)
+  private Date createdAt;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/entity/User.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.example.purithm.domain.user.entity;
 
+import com.example.purithm.domain.filter.entity.Membership;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,6 +25,7 @@ public class User {
   private String username;
   private String profile;
   private boolean terms;
+  private Membership membership;
 
   public void agreeToTerms() {
     this.terms = true;

--- a/purithm/src/main/java/com/example/purithm/global/exception/Error.java
+++ b/purithm/src/main/java/com/example/purithm/global/exception/Error.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum Error {
   /* 400 */
   BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, 40000, "적절하지 않은 요청입니다."),
+  NOT_ACCEPTABLE_OS(HttpStatus.BAD_REQUEST, 40001, "지원하지 않는 OS 기종입니다."),
 
   /* 401 */
   INVALID_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, 40100, "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] 홈홤면에서 필터 조회 API
    - iOS/AOS, 최신순/오래된순/인기순 정렬
    - pagenation 방식으로 조회
    - 회원 등급에 따라 접근할 수 있는 필터인지 아닌지 파악할 수 있는 `canAccess` 필드 응답에 추가

- [x] 필터 상세 정보 조회 API
    - 필터 보정값 제외한 상세 정보들 조회

- [x] 필터 보정값 조회 API

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

- 필터값 조회하는 API를 `/api/filters/{filterId}/AOS` 랑 `/api/filters/{filterId}/iOS` 로 나눴다.
    - 저렇게 path variable 로 줄까, query parameter로 줄까 고민했다. 처음에는 query parameter로 os 값을 받고 둘의 부모 클래스 하나 정의해둔 다음(예를 들어 `FilterDetailDto` 이런 거), 각각 이를 상속받아서 API 응답은 `FilterDetailDto`로 동일하게 내려주려고 했다.
        - 예를 들어서 `/api/filters/{filterId}?os=AOS` 이런 식으로 API 설계하고, 응답은 각 DetailDto의 상위 클래스인 FilterDetailDto로 통일
    - 그런데 iOS 필터랑 AOS 필터가 값 자체가 많이 달라서 이 둘의 부모 클래스로 정의할 `FilterDetailDto` 가 모호해짐
    - `FilterDetailDto` 가 그 자체로도 필터상세 정보(작가 이름, 필터 관련 사진, 리뷰 지수, 리뷰 수 등)를 가지고 있어서 이를 상속받아서 `AOSFilterDetailDto` 이런 걸 구현하게 되면 dto 값이 너무 많아짐
        - 기획 상에도 필터상세 정보와 필터값 조회가 나뉘어 있어서 굳이 이렇게 한번에 다 내려줄 필요 없음
    - iOS 필터랑 AOS 필터가 값 자체도 많이 달라서 API 응답을 내려줄 때 둘을 한 번에 내려주기 적절한 클래스를 따로 만들기도 애매해서.. API를 두 개로 분리했다.

- [JPA에서 엔티티 저장 시간을 자동 생성하는 방법](https://sokdak-sokdak.tistory.com/2)
- [Spring Data JPA Auditing으로 엔티티의 생성/수정 시각 자동으로 기록](https://hudi.blog/spring-data-jpa-auditing-create-update-date/)
- [Spring Data JPA를 활용한 데이터 정렬 구현(JPA method & Pageable, Page)](https://velog.io/@kimdy0915/Spring-Data-JPA%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%A0%95%EB%A0%AC-%EA%B5%AC%ED%98%84JPA-method-Pageable-Page)
- [[사소한 TIP] Spring Data JPA에서 FindBy 와 FindAllBy 차이점](https://revf.tistory.com/270)
- [findAll, findById의 차이](https://velog.io/@lsj8367/findAll-findById%EC%9D%98-%EC%B0%A8%EC%9D%B4)
- [Java Constructors vs Static Factory Methods](https://www.baeldung.com/java-constructors-vs-static-factory-methods)
- [JPA 외래키를 기본키로 사용하기](https://goslim56.tistory.com/18)