### PR TITLE
Feat(#16): 필터 좋아요 기능 추가

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -37,7 +37,7 @@ public class FilterController implements FilterControllerDocs {
 
   @GetMapping("/{filterId}")
   public SuccessResponse<FilterDetailDto> getFilterDetail(Long id, Long filterId) {
-    return SuccessResponse.of(filterService.getFilterDetail(filterId));
+    return SuccessResponse.of(filterService.getFilterDetail(id, filterId));
   }
 
   @GetMapping("/{filterId}/AOS")

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterController.java
@@ -10,15 +10,12 @@ import com.example.purithm.domain.filter.entity.OS;
 import com.example.purithm.domain.filter.service.FilterService;
 import com.example.purithm.global.response.SuccessResponse;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -61,14 +58,14 @@ public class FilterController implements FilterControllerDocs {
   }
 
   @PostMapping("/{filterId}/likes")
-  public SuccessResponse<Boolean> likes(String authorization, Long filterId) {
-    return null;
+  public SuccessResponse<Boolean> likes(Long id, Long filterId) {
+    filterService.likeFilter(id, filterId);
+    return SuccessResponse.of();
   }
 
   @DeleteMapping("/{filterId}/likes")
-  public SuccessResponse<Boolean> deleteLikes(
-      @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
-      @PathVariable Long filterId) {
-    return null;
+  public SuccessResponse<Boolean> deleteLikes(Long id, Long filterId) {
+    filterService.dislikeFilter(id, filterId);
+    return SuccessResponse.of();
   }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/controller/FilterControllerDocs.java
@@ -68,12 +68,12 @@ public interface FilterControllerDocs {
   @Operation(summary = "필터 좋아요를 누릅니다.")
   @ApiResponse(responseCode = "200", description = "필터 좋아요 누르기 성공")
   public SuccessResponse<Boolean> likes(
-      @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
+      @LoginInfo Long id,
       @PathVariable Long filterId);
 
   @Operation(summary = "필터 좋아요를 취소합니다.")
   @ApiResponse(responseCode = "200", description = "필터 좋아요 취소하기 성공")
   public SuccessResponse<Boolean> deleteLikes(
-      @RequestHeader(value = "Authorization") @Parameter(description = "인증 토큰") String authorization,
+      @LoginInfo Long id,
       @PathVariable Long filterId);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDetailDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDetailDto.java
@@ -18,4 +18,6 @@ public class FilterDetailDto {
     int pureDegree;
     @Schema(description = "필터 사진")
     List<String> pictures;
+    @Schema(description = "좋아요 여부")
+    boolean liked;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterDto.java
@@ -23,10 +23,12 @@ public record FilterDto(
     @Schema(description = "좋아요 수")
     int likes,
     @Schema(description = "필터 접근 가능 여부")
-    boolean canAccess
+    boolean canAccess,
+    @Schema(description = "좋아요 여부")
+    boolean liked
 
 ) {
-    public static FilterDto of(Filter filter, Membership membership) {
+    public static FilterDto of(Filter filter, Membership membership, boolean liked) {
         return FilterDto.builder()
             .id(filter.getId())
             .membership(filter.getMembership())
@@ -36,6 +38,7 @@ public record FilterDto(
             .photographerName(filter.getPhotographer().getUsername())
             .likes(filter.getLikes())
             .canAccess(checkAccess(membership, filter.getMembership()))
+            .liked(liked)
             .build();
     }
 

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/FilterLike.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/FilterLike.java
@@ -1,0 +1,28 @@
+package com.example.purithm.domain.filter.entity;
+
+import com.example.purithm.domain.user.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class FilterLike {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "filter_id")
+	private Filter filter;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/entity/FilterLike.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/entity/FilterLike.java
@@ -9,10 +9,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class FilterLike {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterLikeRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterLikeRepository.java
@@ -4,10 +4,9 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.example.purithm.domain.filter.entity.Filter;
 import com.example.purithm.domain.filter.entity.FilterLike;
-import com.example.purithm.domain.user.entity.User;
 
 public interface FilterLikeRepository extends JpaRepository<FilterLike, Long> {
-	Optional<FilterLike> findByFilterAndUser(Filter filter, User user);
+	Optional<FilterLike> findByFilterIdAndUserId(Long filterId, Long userId);
+	void deleteByFilterIdAndUserId(Long filterId, Long userId);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterLikeRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/FilterLikeRepository.java
@@ -1,0 +1,13 @@
+package com.example.purithm.domain.filter.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.purithm.domain.filter.entity.Filter;
+import com.example.purithm.domain.filter.entity.FilterLike;
+import com.example.purithm.domain.user.entity.User;
+
+public interface FilterLikeRepository extends JpaRepository<FilterLike, Long> {
+	Optional<FilterLike> findByFilterAndUser(Filter filter, User user);
+}


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] 좋아요 API 구현
- [x] 좋아요 취소 API 구현
- [x] 필터 조회 시 좋아요 여부 값 추가 


## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

어떤 유저가 특정 자원(여기서는 필터)에 대해 좋아요 눌렀는지 확인할 때
- 필터 조회 시 response 필드 값으로 `liked` 같은 속성 넣기
- 좋아요 여부를 조회할 수 있는 다른 API 만들기
    - 이 방식이 조금 더 restful 하나 좋아요 여부를 알기 위해 또 네트워크 통해서 API를 호출해야 하고 비효율적이라고 생각이 들어서 응답 필드에 추가하기로 했다

나중에 조회를 더 효율적으로 할 수 있도록 개선해보면 좋을듯..

[[게시판] 게시글 좋아요 / 좋아요 취소](https://jindevelopetravel0919.tistory.com/80)
[좋아요 기능 구현](https://back-stead.tistory.com/77)
[🤔 게시물 "좋아요" 여부를 어떻게 설계할까?](https://velog.io/@heunyam/API-%EC%84%A4%EA%B3%84-%EA%B2%8C%EC%8B%9C%EB%AC%BC%EC%97%90-%EB%8C%80%ED%95%9C-%EC%A2%8B%EC%95%84%EC%9A%94-%EC%97%AC%EB%B6%80)