### PR TITLE
Fix(#62): PresignedUrl 업로드 ContentType 지정

### DIFF
--- a/purithm/src/main/java/com/example/purithm/global/aws/service/FileService.java
+++ b/purithm/src/main/java/com/example/purithm/global/aws/service/FileService.java
@@ -29,6 +29,7 @@ public class FileService {
 		String path = generatePath(prefix, id);
 		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, path)
 			.withMethod(HttpMethod.PUT)
+			.withContentType("image/png")
 			.withExpiration(getPresignedUrlExpiration());
 
 		generatePresignedUrlRequest.addRequestParameter(


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] `image/png` 로 `ContentType` 지정

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

왜 `binary/octet-stream` 타입으로 올라가는거지