### PR TITLE
Fix(#18): 리뷰 작성 여부 값 추가

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterReviewDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterReviewDto.java
@@ -9,6 +9,10 @@ import lombok.Builder;
 public record FilterReviewDto(
 	@Schema(description = "평균 퓨어지수")
 	int avg,
+	@Schema(description = "사용자가 해당 필터에 리뷰를 작성했는지")
+	boolean hasReview,
+	@Schema(description = "작성한 리뷰 id", nullable = true)
+	Long reviewId,
 	@Schema(description = "사용자가 필터를 열람한 적 있는지 여부")
 	boolean hasViewed,
 	@Schema(description = "리뷰")


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->


## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->


> java.util.concurrent.atomic 패키지에 속하는 클래스로, 주로 다중 스레드 환경에서 스레드 안전하게 값을 읽고 쓸 수 있도록 설계되었습니다.


1. AtomicBoolean:
    - AtomicBoolean은 불리언 값을 갖는 객체로, 스레드 간의 경쟁 상태 없이 안전하게 값을 업데이트하거나 읽을 수 있게 해줍니다.
    - 스레드 간 동기화가 필요한 경우 사용됩니다. 예를 들어, 여러 스레드가 특정 boolean 플래그를 변경하는 작업을 할 때 사용합니다.

2. AtomicReference<T>:
    - AtomicReference는 T 타입의 참조를 갖는 객체로, 스레드 안전하게 참조 값을 업데이트하거나 읽을 수 있게 해줍니다.
    - 이 역시 다중 스레드 환경에서 참조형 변수를 안전하게 사용하고자 할 때 주로 사용됩니다.
