### PR TITLE
Fix(#18): Atomic 값 객체로 생성

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
@@ -215,7 +215,7 @@ public class FilterService {
 	public FilterReviewDto getReviews(Long userId, Long filterId) {
 		Integer avg = reviewRepository.getAverage(filterId);
 		AtomicBoolean hasReview = new AtomicBoolean(false);
-		AtomicReference<Long> id = null;
+		AtomicReference<Long> id = new AtomicReference<>(null);
 
 		List<ReviewDto> reviews = reviewRepository.findAllByFilterId(filterId)
 			.stream().map(review -> {


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

기존에는 null로 바로 초기화

```java
AtomicReference<Long> id = null;
```

new 키워드로 객체 생성하는 방식으로 수정

```java
AtomicReference<Long> id = new AtomicReference<>(null);
```

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
