### PR TITLE
Fix(#84): 마이페이지 api 응답 수정

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/DatedFilterDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/DatedFilterDto.java
@@ -21,11 +21,11 @@ public class DatedFilterDto {
 	int totalCount;
 
 	@Schema(description = "필터 리스트")
-	List<GroupedFilter> list;
+	List<GroupedFilterLogDto> list;
 
 	public static DatedFilterDto of(List<ViewHistoryProjection> result) {
 		List<FilterLogDto> filterLogs = FilterLogDto.of(result);
-		List<GroupedFilter> groupedFilters = GroupedFilter.groupByDate(filterLogs);
+		List<GroupedFilterLogDto> groupedFilters = GroupedFilterLogDto.groupByDate(filterLogs);
 
 		return DatedFilterDto.builder()
 			.totalCount(filterLogs.size())
@@ -34,13 +34,14 @@ public class DatedFilterDto {
 	}
 }
 
+
 @Getter
 @Builder
-class GroupedFilter {
+class GroupedFilterLogDto {
 	String date;
-	List<FilterLogDto> filterLogs;
+	List<FilterLogDto> filters;
 
-	public static List<GroupedFilter> groupByDate(List<FilterLogDto> filterLogs) {
+	public static List<GroupedFilterLogDto> groupByDate(List<FilterLogDto> filterLogs) {
 		Map<String, List<FilterLogDto>> groupedMap = new HashMap<>();
 		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -49,11 +50,11 @@ class GroupedFilter {
 			groupedMap.computeIfAbsent(date, k -> new ArrayList<>()).add(filterLog);
 		}
 
-		List<GroupedFilter> groupedFilters = new ArrayList<>();
+		List<GroupedFilterLogDto> groupedFilters = new ArrayList<>();
 		for (Map.Entry<String, List<FilterLogDto>> entry : groupedMap.entrySet()) {
-			GroupedFilter groupedFilter = GroupedFilter.builder()
+			GroupedFilterLogDto groupedFilter = GroupedFilterLogDto.builder()
 				.date(entry.getKey())
-				.filterLogs(entry.getValue())
+				.filters(entry.getValue())
 				.build();
 			groupedFilters.add(groupedFilter);
 		}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/DatedFilterDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/DatedFilterDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.example.purithm.domain.filter.entity.Membership;
+import com.example.purithm.domain.filter.repository.projection.ViewHistoryProjection;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -15,18 +16,18 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class FilterViewHistoryDto {
+public class DatedFilterDto {
 	@Schema(description = "총 개수")
 	int totalCount;
 
 	@Schema(description = "필터 리스트")
 	List<GroupedFilter> list;
 
-	public static FilterViewHistoryDto of(List<Object[]> result) {
+	public static DatedFilterDto of(List<ViewHistoryProjection> result) {
 		List<FilterLogDto> filterLogs = FilterLogDto.of(result);
 		List<GroupedFilter> groupedFilters = GroupedFilter.groupByDate(filterLogs);
 
-		return FilterViewHistoryDto.builder()
+		return DatedFilterDto.builder()
 			.totalCount(filterLogs.size())
 			.list(groupedFilters)
 			.build();
@@ -79,16 +80,16 @@ class FilterLogDto {
 	@Schema(description = "리뷰 id", nullable = true)
 	Long reviewId;
 
-	public static List<FilterLogDto> of(List<Object[]> result) {
+	public static List<FilterLogDto> of(List<ViewHistoryProjection> result) {
 		return result.stream().map(res ->
 			FilterLogDto.builder()
-				.filterId((Long)res[0])
-				.filterName((String)res[1])
-				.photographer((String)res[2])
-				.membership((Membership)res[3])
-				.createdAt((Date)res[4])
-				.hasReview(res[5] != null ? true : false)
-				.reviewId((Long)res[5])
+				.filterId(res.getFilterId())
+				.filterName(res.getFilterName())
+				.photographer(res.getPhotographer())
+				.membership(res.getMembership())
+				.createdAt(res.getCreatedAt())
+				.hasReview(res.getReviewId() != null ? true : false)
+				.reviewId(res.getReviewId())
 				.build()
 		).toList();
 	}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/DatedStampDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/DatedStampDto.java
@@ -1,0 +1,101 @@
+package com.example.purithm.domain.filter.dto.response;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.example.purithm.domain.filter.entity.Filter;
+import com.example.purithm.domain.filter.entity.Membership;
+import com.example.purithm.domain.photographer.entity.Photographer;
+import com.example.purithm.domain.review.entity.Review;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DatedStampDto {
+	@Schema(description = "총 개수")
+	int totalCount;
+
+	@Schema(description = "필터 리스트")
+	List<GroupedStampDto> list;
+
+	public static DatedStampDto of(List<Review> reviews) {
+		List<StampDto> stamps = StampDto.of(reviews);
+		List<GroupedStampDto> groupedStamps = GroupedStampDto.groupByDate(stamps);
+
+		return DatedStampDto.builder()
+			.totalCount(stamps.size())
+			.list(groupedStamps)
+			.build();
+	}
+}
+
+@Getter
+@Builder
+class GroupedStampDto {
+	String date;
+	List<StampDto> stamps;
+
+	public static List<GroupedStampDto> groupByDate(List<StampDto> stampDtos) {
+		Map<String, List<StampDto>> groupedMap = new HashMap<>();
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+
+		for(StampDto stampDto : stampDtos) {
+			String date = formatter.format(stampDto.getCreatedAt());
+			groupedMap.computeIfAbsent(date, k -> new ArrayList<>()).add(stampDto);
+		}
+
+		List<GroupedStampDto> groupedStamps = new ArrayList<>();
+		for (Map.Entry<String, List<StampDto>> entry : groupedMap.entrySet()) {
+			GroupedStampDto groupedStamp = GroupedStampDto.builder()
+				.date(entry.getKey())
+				.stamps(entry.getValue())
+				.build();
+			groupedStamps.add(groupedStamp);
+		}
+
+		return groupedStamps;
+	}
+}
+
+@Getter
+@Builder
+class StampDto {
+	@Schema(description = "스탬프 관련 필터 id")
+	Long filterId;
+	@Schema(description = "스탬프 관련 필터 이름")
+	String filterName;
+	@Schema(description = "스탬프 관련 필터 작가 이름")
+	String photographer;
+	@Schema(description = "스탬프 관련 필터 프로필")
+	String thumbnail;
+	@Schema(description = "스탬프 관련 리뷰 생성일")
+	Date createdAt;
+	@Schema(description = "스탬프 관련 필터 등급")
+	Membership membership;
+	@Schema(description = "리뷰 id")
+	Long reviewId;
+
+	public static List<StampDto> of(List<Review> result) {
+		return result.stream().map(res -> {
+				Filter filter = res.getFilter();
+				Photographer photographer = filter.getPhotographer();
+				return StampDto.builder()
+					.filterId(filter.getId())
+					.filterName(filter.getName())
+					.photographer(photographer.getUsername())
+					.thumbnail(filter.getThumbnail())
+					.membership(filter.getMembership())
+					.createdAt(res.getCreatedAt())
+					.reviewId(res.getId())
+					.build();
+			}
+		).toList();
+	}
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterViewHistoryDto.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/dto/response/FilterViewHistoryDto.java
@@ -1,27 +1,95 @@
 package com.example.purithm.domain.filter.dto.response;
 
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.example.purithm.domain.filter.entity.Membership;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
-public record FilterViewHistoryDto(
+public class FilterViewHistoryDto {
+	@Schema(description = "총 개수")
+	int totalCount;
+
+	@Schema(description = "필터 리스트")
+	List<GroupedFilter> list;
+
+	public static FilterViewHistoryDto of(List<Object[]> result) {
+		List<FilterLogDto> filterLogs = FilterLogDto.of(result);
+		List<GroupedFilter> groupedFilters = GroupedFilter.groupByDate(filterLogs);
+
+		return FilterViewHistoryDto.builder()
+			.totalCount(filterLogs.size())
+			.list(groupedFilters)
+			.build();
+	}
+}
+
+@Getter
+@Builder
+class GroupedFilter {
+	String date;
+	List<FilterLogDto> filterLogs;
+
+	public static List<GroupedFilter> groupByDate(List<FilterLogDto> filterLogs) {
+		Map<String, List<FilterLogDto>> groupedMap = new HashMap<>();
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+
+		for(FilterLogDto filterLog : filterLogs) {
+			String date = formatter.format(filterLog.getCreatedAt());
+			groupedMap.computeIfAbsent(date, k -> new ArrayList<>()).add(filterLog);
+		}
+
+		List<GroupedFilter> groupedFilters = new ArrayList<>();
+		for (Map.Entry<String, List<FilterLogDto>> entry : groupedMap.entrySet()) {
+			GroupedFilter groupedFilter = GroupedFilter.builder()
+				.date(entry.getKey())
+				.filterLogs(entry.getValue())
+				.build();
+			groupedFilters.add(groupedFilter);
+		}
+
+		return groupedFilters;
+	}
+}
+
+@Getter
+@Builder
+class FilterLogDto {
 	@Schema(description = "필터 id")
-	Long filterId,
+	Long filterId;
 	@Schema(description = "필터 이름")
-	String filterName,
+	String filterName;
 	@Schema(description = "작가 이름")
-	String photographer,
+	String photographer;
 	@Schema(description = "필터 멤버십")
-	Membership membership,
+	Membership membership;
 	@Schema(description = "필터 열람일")
-	Date createdAt,
+	Date createdAt;
 	@Schema(description = "해당 필터에 작성한 리뷰가 있는지 여부")
-	boolean hasReview,
+	boolean hasReview;
 	@Schema(description = "리뷰 id", nullable = true)
-	Long reviewId
-) {
+	Long reviewId;
+
+	public static List<FilterLogDto> of(List<Object[]> result) {
+		return result.stream().map(res ->
+			FilterLogDto.builder()
+				.filterId((Long)res[0])
+				.filterName((String)res[1])
+				.photographer((String)res[2])
+				.membership((Membership)res[3])
+				.createdAt((Date)res[4])
+				.hasReview(res[5] != null ? true : false)
+				.reviewId((Long)res[5])
+				.build()
+		).toList();
+	}
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/UserFilterLogRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/UserFilterLogRepository.java
@@ -8,16 +8,17 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.purithm.domain.filter.entity.UserFilterLog;
+import com.example.purithm.domain.filter.repository.projection.ViewHistoryProjection;
 
 @Repository
 public interface UserFilterLogRepository extends JpaRepository<UserFilterLog, Long> {
 	boolean existsByFilterIdAndUserId(Long filterId, Long userId);
 
-	@Query("SELECT f.id, f.name, p.username, f.membership, ufl.createdAt, r.id " +
+	@Query("SELECT f.id AS filterId, f.name AS filterName, p.username AS photographer, f.membership AS membership, ufl.createdAt AS createdAt, r.id AS reviewId " +
 		"FROM UserFilterLog ufl "
 		+ "LEFT JOIN Filter f ON ufl.filterId = f.id "
 		+ "LEFT JOIN Review r ON r.filter.id = f.id AND r.user.id=:userId "
 		+ "LEFT JOIN Photographer  p ON p.id = f.photographer.id "
 		+ "WHERE ufl.userId=:userId")
-	List<Object[]> getFilterViewHistory(@Param("userId") Long userId);
+	List<ViewHistoryProjection> getFilterViewHistory(@Param("userId") Long userId);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/filter/repository/projection/ViewHistoryProjection.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/repository/projection/ViewHistoryProjection.java
@@ -1,0 +1,14 @@
+package com.example.purithm.domain.filter.repository.projection;
+
+import java.util.Date;
+
+import com.example.purithm.domain.filter.entity.Membership;
+
+public interface ViewHistoryProjection {
+	Long getFilterId();
+	String getFilterName();
+	String getPhotographer();
+	Membership getMembership();
+	Date getCreatedAt();
+	Long getReviewId();
+}

--- a/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
@@ -11,8 +11,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.purithm.domain.filter.dto.response.DatedFilterDto;
 import com.example.purithm.domain.filter.dto.response.FilterDescriptionDto;
-import com.example.purithm.domain.filter.dto.response.FilterViewHistoryDto;
 import com.example.purithm.domain.filter.dto.response.FilterPictureDto;
 import com.example.purithm.domain.filter.dto.response.LikedFilterDto;
 import com.example.purithm.domain.filter.dto.response.filterDetailValue.AOSFilterDetailDto;
@@ -243,8 +243,8 @@ public class FilterService {
 		return FilterDescriptionDto.of(filter);
 	}
 
-	public FilterViewHistoryDto getFilterViewHistory(Long userId) {
-		return FilterViewHistoryDto.of(userFilterLogRepository.getFilterViewHistory(userId));
+	public DatedFilterDto getFilterViewHistory(Long userId) {
+		return DatedFilterDto.of(userFilterLogRepository.getFilterViewHistory(userId));
 	}
 
 	public List<LikedFilterDto> getLikedFilters(Long userId) {

--- a/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/filter/service/FilterService.java
@@ -1,6 +1,5 @@
 package com.example.purithm.domain.filter.service;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -244,18 +243,8 @@ public class FilterService {
 		return FilterDescriptionDto.of(filter);
 	}
 
-	public List<FilterViewHistoryDto> getFilterViewHistory(Long userId) {
-		return userFilterLogRepository.getFilterViewHistory(userId)
-			.stream().map(result ->
-				FilterViewHistoryDto.builder()
-					.filterId((Long)result[0])
-					.filterName((String)result[1])
-					.photographer((String)result[2])
-					.membership((Membership)result[3])
-					.createdAt((Date)result[4])
-					.hasReview(result[5] != null ? true : false)
-					.reviewId((Long)result[5])
-					.build()).toList();
+	public FilterViewHistoryDto getFilterViewHistory(Long userId) {
+		return FilterViewHistoryDto.of(userFilterLogRepository.getFilterViewHistory(userId));
 	}
 
 	public List<LikedFilterDto> getLikedFilters(Long userId) {

--- a/purithm/src/main/java/com/example/purithm/domain/review/service/ReviewService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.purithm.domain.feed.dto.response.FeedDto;
+import com.example.purithm.domain.filter.dto.response.DatedStampDto;
 import com.example.purithm.domain.filter.entity.Filter;
 import com.example.purithm.domain.filter.entity.OS;
 import com.example.purithm.domain.filter.repository.FilterRepository;
@@ -14,7 +15,6 @@ import com.example.purithm.domain.review.dto.response.CreatedReviewDto;
 import com.example.purithm.domain.review.dto.response.ReviewResponseDto;
 import com.example.purithm.domain.review.entity.Review;
 import com.example.purithm.domain.review.repository.ReviewRepository;
-import com.example.purithm.domain.user.dto.response.StampDto;
 import com.example.purithm.domain.user.entity.User;
 import com.example.purithm.domain.user.repository.UserRepository;
 import com.example.purithm.global.exception.CustomException;
@@ -128,20 +128,8 @@ public class ReviewService {
 		reviewRepository.deleteByIdAndUserId(reviewId, userId);
 	}
 
-	public List<StampDto> getStamps(Long userId) {
+	public DatedStampDto getStamps(Long userId) {
 		List<Review> reviews = reviewRepository.findAllByUserId(userId);
-		return reviews.stream().map(review ->
-		{
-			Filter filter = review.getFilter();
-			return StampDto.builder()
-				.filterId(filter.getId())
-				.filterName(filter.getName())
-				.photographer(filter.getPhotographer().getUsername())
-				.thumbnail(filter.getThumbnail())
-				.createdAt(review.getCreatedAt())
-				.membership(filter.getMembership())
-				.reviewId(review.getId())
-				.build();
-		}).toList();
+		return DatedStampDto.of(reviews);
 	}
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
@@ -76,7 +76,7 @@ public class UserController implements UserControllerDocs {
   }
 
   @GetMapping("/history")
-  public SuccessResponse<List<FilterViewHistoryDto>> getFilterViewHistory(Long id) {
+  public SuccessResponse<FilterViewHistoryDto> getFilterViewHistory(Long id) {
     return SuccessResponse.of(filterService.getFilterViewHistory(id));
   }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
@@ -2,12 +2,12 @@ package com.example.purithm.domain.user.controller;
 
 import com.example.purithm.domain.feed.dto.response.FeedDto;
 import com.example.purithm.domain.filter.dto.response.DatedFilterDto;
+import com.example.purithm.domain.filter.dto.response.DatedStampDto;
 import com.example.purithm.domain.filter.dto.response.LikedFilterDto;
 import com.example.purithm.domain.filter.service.FilterService;
 import com.example.purithm.domain.review.service.ReviewService;
 import com.example.purithm.domain.user.dto.request.UserInfoRequestDto;
 import com.example.purithm.domain.user.dto.response.AccountInfoDto;
-import com.example.purithm.domain.user.dto.response.StampDto;
 import com.example.purithm.domain.user.dto.response.UserInfoDto;
 import com.example.purithm.domain.user.service.UserService;
 import com.example.purithm.global.response.SuccessResponse;
@@ -55,7 +55,7 @@ public class UserController implements UserControllerDocs {
   }
 
   @GetMapping("/stamps")
-  public SuccessResponse<List<StampDto>> getStamp(Long id) {
+  public SuccessResponse<DatedStampDto> getStamp(Long id) {
     return SuccessResponse.of(reviewService.getStamps(id));
   }
 

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.example.purithm.domain.user.controller;
 
 import com.example.purithm.domain.feed.dto.response.FeedDto;
-import com.example.purithm.domain.filter.dto.response.FilterViewHistoryDto;
+import com.example.purithm.domain.filter.dto.response.DatedFilterDto;
 import com.example.purithm.domain.filter.dto.response.LikedFilterDto;
 import com.example.purithm.domain.filter.service.FilterService;
 import com.example.purithm.domain.review.service.ReviewService;
@@ -76,7 +76,7 @@ public class UserController implements UserControllerDocs {
   }
 
   @GetMapping("/history")
-  public SuccessResponse<FilterViewHistoryDto> getFilterViewHistory(Long id) {
+  public SuccessResponse<DatedFilterDto> getFilterViewHistory(Long id) {
     return SuccessResponse.of(filterService.getFilterViewHistory(id));
   }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
@@ -1,7 +1,7 @@
 package com.example.purithm.domain.user.controller;
 
 import com.example.purithm.domain.feed.dto.response.FeedDto;
-import com.example.purithm.domain.filter.dto.response.FilterViewHistoryDto;
+import com.example.purithm.domain.filter.dto.response.DatedFilterDto;
 import com.example.purithm.domain.filter.dto.response.LikedFilterDto;
 import com.example.purithm.domain.user.dto.request.UserInfoRequestDto;
 import com.example.purithm.domain.user.dto.response.AccountInfoDto;
@@ -53,5 +53,5 @@ public interface UserControllerDocs {
 
   @Operation(summary = "필터 열람 내역을 조회합니다.")
   @ApiResponse(responseCode = "200", description = "필터 열람 내역 조회 성공")
-  public SuccessResponse<FilterViewHistoryDto> getFilterViewHistory(@LoginInfo Long id);
+  public SuccessResponse<DatedFilterDto> getFilterViewHistory(@LoginInfo Long id);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
@@ -2,10 +2,10 @@ package com.example.purithm.domain.user.controller;
 
 import com.example.purithm.domain.feed.dto.response.FeedDto;
 import com.example.purithm.domain.filter.dto.response.DatedFilterDto;
+import com.example.purithm.domain.filter.dto.response.DatedStampDto;
 import com.example.purithm.domain.filter.dto.response.LikedFilterDto;
 import com.example.purithm.domain.user.dto.request.UserInfoRequestDto;
 import com.example.purithm.domain.user.dto.response.AccountInfoDto;
-import com.example.purithm.domain.user.dto.response.StampDto;
 import com.example.purithm.domain.user.dto.response.UserInfoDto;
 import com.example.purithm.global.auth.annotation.LoginInfo;
 import com.example.purithm.global.response.SuccessResponse;
@@ -36,7 +36,7 @@ public interface UserControllerDocs {
 
   @Operation(summary = "내 스탬프를 조회합니다.")
   @ApiResponse(responseCode = "200", description = "내 스탬프 조회 성공")
-  public SuccessResponse<List<StampDto>> getStamp(@LoginInfo Long id);
+  public SuccessResponse<DatedStampDto> getStamp(@LoginInfo Long id);
 
   @Operation(summary = "내 리뷰를 조회합니다.")
   @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공")

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
@@ -53,5 +53,5 @@ public interface UserControllerDocs {
 
   @Operation(summary = "필터 열람 내역을 조회합니다.")
   @ApiResponse(responseCode = "200", description = "필터 열람 내역 조회 성공")
-  public SuccessResponse<List<FilterViewHistoryDto>> getFilterViewHistory(@LoginInfo Long id);
+  public SuccessResponse<FilterViewHistoryDto> getFilterViewHistory(@LoginInfo Long id);
 }


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

close #84 

- 필터 열람 내역 응답 수정
- 스탬프 조회 응답 수정

</br>

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

둘이 응답이 비슷해서 하나로 합치고 싶었는데 잘 안 돼서 그냥 분리했다...

- `DatedFilterDto`로 해서 날짜 단위로 묶인 필터들 반환하는 DTO를 하나 만들어서 두 개가 공유해서 쓰도록 하려고 했음. 오버로딩으로 잘 어찌저찌해서 하나로 퉁치려고 했다.. 아래와 같은 느낌으로

```java
public class DatedFilterDto {

    @Schema(description = "총 개수")
    int totalCount;

    @Schema(description = "필터 리스트")
    List<GroupedFilter> list;

    public static DatedFilterDto of(List<ViewHistoryProjection> result) {
        List<FilterLogDto> filterLogs = FilterLogDto.of(result);
        List<GroupedFilter> groupedFilters = GroupedFilter.groupByDate(filterLogs);

        return DatedFilterDto.builder()
            .totalCount(filterLogs.size())
            .list(groupedFilters)
            .build();
    }

    public static DatedFilterDto of(List<Review> reviews) {
        List<FilterLogDto> filterLogs = reviews.stream()
            .map(review -> /* Review 객체를 FilterLogDto로 변환하는 로직 */)
            .collect(Collectors.toList());

        List<GroupedFilter> groupedFilters = GroupedFilter.groupByDate(filterLogs);

        return DatedFilterDto.builder()
            .totalCount(filterLogs.size())
            .list(groupedFilters)
            .build();
    }
}

```

</br>

- 여기서 문제는....
    - `ViewHistoryProjection`가 interface여서 제네릭 타입의 타입 소거(Type Erasure) 때문에 List<ViewHistoryProjection>과 List<Review> 메소드가 오버로딩이 안 되고 충돌함.
        > 'of(List<ViewHistoryProjection>)' clashes with 'of(List<Review>)'; both methods have same erasure
        그럼 `ViewHistoryProjection`를 interface에서 class로 바꿀까? 했는데 찾아보니 interface 방식이 더 간편한거 같아서 유지하기로 했다.    
    - `필터 열람 내역 응답` 에는 `hasReview` 값이 있어야 했고 `스탬프 조회 응답`에는 없어야 했음

</br>

이런 문제들 때문에 분리와 합침을 반복하다가... 그냥 필터 열람 내역과 스탬프 조회를 분리하기로 했다..
사실 아예 같은 기능이 반복되는 것도 아니고 ~~(그냥 응답이 비슷할 뿐...)~~ 추후에 각자 기능 특성에 맞춰서 API에서 내려줄 값이 달라질 수도 있을 것 같아서 분리했다.

어떻게 코드를 깔끔하게 짤 수 있을까..^ 항상 의문이다!


</br>
</br>


추가적으로 @Builder 애너테이션이 inner class에 적용될 수 없음

> error: @Builder is not supported on non-static nested classes. @Builder ^

Builder는 독립적으로 객체를 생성하는데 inner class는 outer class의 객체화에 영향을 받기 때문에 이를 컴파일할 때부터 오류로 막는다.
즉, outer class 객체가 먼저 만들어지고 inner class가 만들어져야 하는 의존관계가 있는데 `@Builder`는 독립적으로 객체를 생성하는 애라 에러가 남

</br>
</br>

<details>
    <summary>참고</summary>
    <p>
        <a href="https://limdevbasic.tistory.com/28">Nested Class</a></br>
        <a href="https://velog.io/@kangji149/%EC%9E%90%EB%B0%94-Map%EC%9D%98-%EB%A9%94%EC%84%9C%EB%93%9C-computeIfAbsent%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90">자바 Map의 메서드 computeIfAbsent에 대해 알아보자</a></br>
        <a href="https://velog.io/@pjh612/Spring-Data-JPA%EC%97%90%EC%84%9C%EC%9D%98-Projection-%EB%B0%A9%EB%B2%95">Spring Data JPA에서의 Projection 방법</a></br>
    </p>
</details>




