### PR TITLE
Feat(#80): 회원 탈퇴 추가

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserController.java
@@ -79,4 +79,10 @@ public class UserController implements UserControllerDocs {
   public SuccessResponse<DatedFilterDto> getFilterViewHistory(Long id) {
     return SuccessResponse.of(filterService.getFilterViewHistory(id));
   }
+
+  @DeleteMapping
+  public SuccessResponse deleteUser(Long id) {
+    userService.deleteUser(id);
+    return SuccessResponse.of();
+  }
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/controller/UserControllerDocs.java
@@ -54,4 +54,8 @@ public interface UserControllerDocs {
   @Operation(summary = "필터 열람 내역을 조회합니다.")
   @ApiResponse(responseCode = "200", description = "필터 열람 내역 조회 성공")
   public SuccessResponse<DatedFilterDto> getFilterViewHistory(@LoginInfo Long id);
+
+  @Operation(summary = "회원 탈퇴를 할 수 있다.")
+  @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
+  public SuccessResponse deleteUser(@LoginInfo Long id);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/entity/Provider.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/entity/Provider.java
@@ -6,8 +6,7 @@ import lombok.AllArgsConstructor;
 public enum Provider {
 	KAKAO("KAKAO"),
 	APPLE("APPLE"),
-	PURITHM("자체 가입"),
-	WITHDRAW("탈퇴");
+	PURITHM("자체 가입");
 
 	private final String provider;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/entity/Provider.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/entity/Provider.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 public enum Provider {
 	KAKAO("KAKAO"),
 	APPLE("APPLE"),
-	PURITHM("PURITHM");
+	PURITHM("자체 가입"),
+	WITHDRAW("탈퇴");
+
 	private final String provider;
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/entity/User.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/entity/User.java
@@ -69,4 +69,8 @@ public class User {
     this.username = userInfo.name();
   }
 
+  public void withdraw() {
+    this.provider = Provider.WITHDRAW;
+  }
+
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/entity/User.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.purithm.domain.user.entity;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -55,6 +56,9 @@ public class User {
   @Column(updatable = false)
   private Date createdAt;
 
+  @Column(updatable = false)
+  private LocalDateTime deletedAt;
+
   public void agreeToTerms() {
     this.terms = true;
   }
@@ -70,7 +74,7 @@ public class User {
   }
 
   public void withdraw() {
-    this.provider = Provider.WITHDRAW;
+    this.deletedAt = LocalDateTime.now();
   }
 
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/repository/UserRepository.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package com.example.purithm.domain.user.repository;
 
-import java.util.Optional;
+import java.time.LocalDateTime;
 
 import com.example.purithm.domain.user.entity.Provider;
 import com.example.purithm.domain.user.entity.User;
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+  @Query("SELECT u FROM User u WHERE u.provider = :provider AND u.providerId = :providerId AND u.deletedAt IS NULL")
   User findByProviderAndProviderId(Provider provider, String providerId);
 
   @Query("SELECT COUNT(r) FROM Review r WHERE r.user.id = :userId")
@@ -20,7 +21,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
   @Query("SELECT COUNT(ufl) FROM UserFilterLog ufl WHERE ufl.userId = :userId")
   int countLogsByUserId(@Param("userId") Long userId);
 
-  boolean existsByProviderId(String id);
+  @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u "
+      + "WHERE u.provider = :provider AND u.providerId = :providerId AND u.deletedAt IS NOT NULL AND u.deletedAt >= :sevenDaysAgo")
+  boolean existsWithdrawnUser(Provider provider, String providerId, LocalDateTime sevenDaysAgo);
 
-  Optional<User> findByProviderId(String id);
+  @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u "
+      + "WHERE u.id = :userId AND u.deletedAt IS NOT NULL")
+  boolean existsWithdrawnUserById(Long userId);
 }

--- a/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.example.purithm.domain.user.service;
 
+import java.time.LocalDateTime;
+
 import com.example.purithm.domain.filter.entity.Membership;
 import com.example.purithm.domain.user.dto.request.UserInfoRequestDto;
 import com.example.purithm.domain.user.dto.response.AccountInfoDto;
@@ -25,28 +27,35 @@ public class UserService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public Long signUp(SignUpUserInfoDto socialUserInfoDto) {
-    if (socialUserInfoDto.getProvider().equals(Provider.PURITHM)
-        && userRepository.existsByProviderId(socialUserInfoDto.getProviderId())) {
-      throw CustomException.of(Error.NICKNAME_ALREADY_USED_ERROR);
-    }
-
+  public Long signUp(SignUpUserInfoDto signUpUserInfoDto) {
     User existUser = userRepository
-        .findByProviderAndProviderId(socialUserInfoDto.getProvider(), socialUserInfoDto.getProviderId());
+        .findByProviderAndProviderId(signUpUserInfoDto.getProvider(), signUpUserInfoDto.getProviderId());
 
     if (existUser != null) {
+      if (existUser.getProvider().equals(Provider.PURITHM)) {
+        throw CustomException.of(Error.NICKNAME_ALREADY_USED_ERROR);
+      }
       return existUser.getId();
     }
 
+    boolean isWithdrawnUser = userRepository.existsWithdrawnUser(
+        signUpUserInfoDto.getProvider(),
+        signUpUserInfoDto.getProviderId(),
+        LocalDateTime.now().minusDays(7));
+    if (isWithdrawnUser) {
+      throw CustomException.of(Error.WIRHDRAWN_USER_ERROR);
+    }
+
     User user = User.builder()
-        .profile(socialUserInfoDto.getProfile())
-        .provider(socialUserInfoDto.getProvider())
-        .providerId(socialUserInfoDto.getProviderId())
-        .username(socialUserInfoDto.getUsername())
-        .email(socialUserInfoDto.getEmail())
+        .profile(signUpUserInfoDto.getProfile())
+        .provider(signUpUserInfoDto.getProvider())
+        .providerId(signUpUserInfoDto.getProviderId())
+        .username(signUpUserInfoDto.getUsername())
+        .email(signUpUserInfoDto.getEmail())
         .terms(false)
         .membership(Membership.BASIC)
-        .password(passwordEncoder.encode(socialUserInfoDto.getPassword()))
+        .password(passwordEncoder.encode(signUpUserInfoDto.getPassword()))
+        .deletedAt(null)
         .build();
 
     User savedUser = userRepository.save(user);
@@ -104,8 +113,10 @@ public class UserService {
   }
 
   public Long getUserId(LoginRequestDto loginRequestDto) {
-    User user = userRepository.findByProviderId(loginRequestDto.id())
-        .orElseThrow(() -> CustomException.of(Error.NOT_FOUND_ERROR));
+    User user = userRepository.findByProviderAndProviderId(Provider.PURITHM, loginRequestDto.id());
+    if (user == null) {
+      throw CustomException.of(Error.NOT_FOUND_ERROR);
+    }
 
     if (!passwordEncoder.matches(loginRequestDto.password(), user.getPassword())) {
       throw CustomException.of(Error.INVALID_ID_PASSWORD);

--- a/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
@@ -112,4 +112,11 @@ public class UserService {
     }
     return user.getId();
   }
+
+  public void deleteUser(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> CustomException.of(Error.NOT_FOUND_ERROR));
+    user.withdraw();
+    userRepository.save(user);
+  }
 }

--- a/purithm/src/main/java/com/example/purithm/global/exception/Error.java
+++ b/purithm/src/main/java/com/example/purithm/global/exception/Error.java
@@ -20,6 +20,7 @@ public enum Error {
 
   /* 403 */
   NOT_AGREED_TERM(HttpStatus.FORBIDDEN, 40300, "이용약관 동의가 필요합니다"),
+  WIRHDRAWN_USER_ERROR(HttpStatus.FORBIDDEN, 40301, "탈퇴 후 7일이 지나지 않은 재가입 사용자입니다."),
 
   /* 404 */
   NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, 40400, "리소스를 찾을 수 없습니다."),


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

close #80 

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

- hard delete vs soft delete
    - 회원 탈퇴해도 리뷰는 남기기로 하는 요구사항이 있어서 soft delete 선택

- 탈퇴 후 7일간 재가입 불가
    - 탈퇴 시점 `deletedAt` 적어두고 7일 안 됐으면 재가입 안 시킴

- 탈퇴한 사용자 예외처리 어디서?
    - GPT 물어보니까 `AOP`나 `@ControllerAdvice` 말하던데
    - token 안에 들어있는 id 값 찾아주는 argument resolver가 있으니까 그 안에서 걸려줌
        - 예전에는 탈퇴가 없었기 때문에 무조건 있는 user라는 보장이 있었는데, 이제는 id 값에 해당하는 user가 없을 수도 있기 때문에 걸러줌