### PR TITLE
Fix(#114): 중복 회원가입 문제 수정

### DIFF
--- a/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
@@ -64,8 +64,7 @@ public class UserService {
       User savedUser = userRepository.save(user);
       savedUserId = savedUser.getId();
     } catch (DuplicateKeyException e) {
-      log.error("try to save duplicated user");
-      throw CustomException.of(Error.INTERNAL_SERVER_ERROR);
+      throw new RuntimeException("try to save duplicated user");
     }
     return savedUserId;
   }

--- a/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
+++ b/purithm/src/main/java/com/example/purithm/domain/user/service/UserService.java
@@ -17,6 +17,7 @@ import com.example.purithm.global.exception.Error;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -58,8 +59,15 @@ public class UserService {
         .deletedAt(null)
         .build();
 
-    User savedUser = userRepository.save(user);
-    return savedUser.getId();
+    Long savedUserId = null;
+    try {
+      User savedUser = userRepository.save(user);
+      savedUserId = savedUser.getId();
+    } catch (DuplicateKeyException e) {
+      log.error("try to save duplicated user");
+      throw CustomException.of(Error.INTERNAL_SERVER_ERROR);
+    }
+    return savedUserId;
   }
 
   public void agreeToTermsOfUse(Long id) {


### PR DESCRIPTION
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

close #114 

## 고민한 점들
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

동시성 이슈를 해결할 수 있는 방법은 다음과 같다.

- 데이터베이스 수준에서 제약 설정
    - 데이터베이스에서 특정 필드에 대해서 unique 제약조건을 설정해서 중복된 값이 들어오지 않도록 함
    - 중복된 값을 저장하려는 요청이 들어와도 데이터베이스 차원에서 방지
    
- Lock을 걸기
    - 비관적 락
        - DB단에서 Lock
        - row에 락을 걸기 때문에 성능 저하 우려
    - 낙관적 락
        - 애플리케이션 레벨에서 버전을 활용한 Lock
        - 실패할 시에 예외처리+재시도 해줘야하기에 성능저하 우려
    - 분산락
        - 임계영역에 접근할 때 Lock을 획득한 프로세스/스레드만이 접근할 수 있음.
        - 한번에 한 프로세스/스레드만 Lock을 받아서 실행하기 때문에 동시성 문제 해결
        - 서버 분산 환경에서 좋음.
    - 성능 저하의 우려가 있고 deadlock 발생 가능
    
</br>

찾아보았을 때 Lock을 거는건 성능저하와 deadlock의 우려도 있기에 DB column에 Unique 제약조건을 걸어두고 에러가 터졌을 때 이를 핸들링해주는 방식 선택

</br>

수정한 코드

⬇️⬇️⬇️⬇️⬇️

```java

    Long savedUserId = null;
    try {
        User savedUser = userRepository.save(user);
        savedUserId = savedUser.getId();
    } catch (DuplicateKeyException e) {
        throw new RuntimeException("try to save duplicated user");
    }
    return savedUserId;
```


중복된 키 에러가 `save` 할 때 발생하면 `RuntimeException` 에러를 throw 한다. 그럼 GlobalExceptionHandler가 메시지로 서버 log 찍고 Internal Server Error를 응답한다.

<a href="https://velog.io/@youmakemesmile/Spring-Data-JPA-JPQL-%EC%82%AC%EC%9A%A9-%EB%B0%A9%EB%B2%95Query-nativeQuery-DTO-Mapping-function">[Spring Data JPA] JPQL 사용 방법(@Query & nativeQuery & DTO Mapping & function)</a> </br>

<a href=""></a></br>

<details>
<summary>참고</summary>
<div markdown="1">
<a href="https://velog.io/@ddh963963/%EB%8F%99%EC%8B%9C%EC%84%B1%EC%9D%B4%EC%8A%88-%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-1%ED%8E%B8">동시성이슈 1편 - 회원가입</a></br>
<a href="https://velog.io/@ddh963963/%EB%8F%99%EC%8B%9C%EC%84%B1%EC%9D%B4%EC%8A%88-2%ED%8E%B8">동시성이슈 2편</a></br>
<a href="https://velog.io/@joydev/doorip-%EC%A4%91%EB%B3%B5-%ED%9A%8C%EC%9B%90%EA%B0%80%EC%9E%85-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C-Trouble-Shooting">[doorip] 중복 회원가입 동시성 문제 Trouble Shooting</a></br>
<a href="https://velog.io/@bagt/Database-%EB%82%99%EA%B4%80%EC%A0%81-%EB%9D%BD-%EB%B9%84%EA%B4%80%EC%A0%81-%EB%9D%BD">[Database] 낙관적 락 / 비관적 락</a></br>
<a href="https://www.inflearn.com/community/questions/59250/%EC%95%88%EB%85%95%ED%95%98%EC%84%B8%EC%9A%94-unique-index-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%A0%80%EC%9E%A5%EC%97%90-%EB%8C%80%ED%95%B4%EC%84%9C-%EC%A7%88%EB%AC%B8%EB%93%9C%EB%A6%BD%EB%8B%88%EB%8B%A4">안녕하세요. Unique Index 데이터 저장에 대해서 질문드립니다.</a></br>
<a href="https://velog.io/@koo8624/Database-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%B2%A0%EC%9D%B4%EC%8A%A4-%EB%9D%BDLock%EC%9D%98-%EC%A2%85%EB%A5%98%EC%99%80-%EC%97%AD%ED%95%A0">[Database] 데이터베이스 락(Lock)의 종류와 역할</a></br>
<a href="https://velog.io/@a01021039107/%EB%B6%84%EC%82%B0%EB%9D%BD%EC%9C%BC%EB%A1%9C-%ED%95%B4%EA%B2%B0%ED%95%98%EB%8A%94-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C%EC%9D%B4%EB%A1%A0%ED%8E%B8">분산락으로 해결하는 동시성 문제(이론편)</a></br>
<a href="https://jaeseongdev.github.io/development/2021/06/16/Lock%EC%9D%98-%EC%A2%85%EB%A5%98-(Shared-Lock,-Exclusive-Lock,-Record-Lock,-Gap-Lock,-Next-key-Lock)/">Lock의 종류 (Shared Lock, Exclusive Lock, Record Lock, Gap Lock, Next-key Lock)</a></br>
<a href="https://kay0426.tistory.com/70">Clustered Index와 Secondary Index</a></br>
</div>
</details>